### PR TITLE
Fix: Images not displaying from JSON in Windows app

### DIFF
--- a/lib/src/stack_board_items/items/stack_image_item.dart
+++ b/lib/src/stack_board_items/items/stack_image_item.dart
@@ -26,24 +26,24 @@ class ImageItemContent extends StackItemContent {
     _init();
   }
 
-  factory ImageItemContent.fromJson(Map<String, dynamic> json) {
-    return ImageItemContent(
-      url: json['assetName'] != null ? null : asT<String>(json['url']),
-      assetName: json['url'] != null ? null : asT<String>(json['assetName']),
-      semanticLabel: asT<String>(json['semanticLabel']),
-      excludeFromSemantics: asT<bool>(json['excludeFromSemantics'], false),
-      width: asT<double>(json['width']),
-      height: asT<double>(json['height']),
-      color: Color(asT<int>(json['color'])),
-      colorBlendMode: BlendMode.values[asT<int>(json['colorBlendMode'])],
-      fit: BoxFit.values[asT<int>(json['fit'])],
-      repeat: ImageRepeat.values[asT<int>(json['repeat'])],
-      matchTextDirection: asT<bool>(json['matchTextDirection'], false),
-      gaplessPlayback: asT<bool>(json['gaplessPlayback'], false),
-      isAntiAlias: asT<bool>(json['isAntiAlias'], false),
-      filterQuality: FilterQuality.values[asT<int>(json['filterQuality'])],
-    );
-  }
+factory ImageItemContent.fromJson(Map<String, dynamic> json) {
+  return ImageItemContent(
+    url: json['url'] != null ? asT<String>(json['url']) : null,
+    assetName: json['assetName'] != null ? asT<String>(json['assetName']) : null,
+    semanticLabel: json['semanticLabel'] != null ? asT<String>(json['semanticLabel']) : null,
+    excludeFromSemantics: json['excludeFromSemantics'] != null ? asT<bool>(json['excludeFromSemantics'], false) : false,
+    width: json['width'] != null ? asT<double>(json['width']) : null,
+    height: json['height'] != null ? asT<double>(json['height']) : null,
+    color: json['color'] != null ? Color(asT<int>(json['color'])) : null,
+    colorBlendMode: json['colorBlendMode'] != null ? BlendMode.values[asT<int>(json['colorBlendMode'])] : BlendMode.srcIn,
+    fit: json['fit'] != null ? BoxFit.values[asT<int>(json['fit'])] : BoxFit.cover,
+    repeat: json['repeat'] != null ? ImageRepeat.values[asT<int>(json['repeat'])] : ImageRepeat.noRepeat,
+    matchTextDirection: json['matchTextDirection'] != null ? asT<bool>(json['matchTextDirection'], false) : false,
+    gaplessPlayback: json['gaplessPlayback'] != null ? asT<bool>(json['gaplessPlayback'], false) : false,
+    isAntiAlias: json['isAntiAlias'] != null ? asT<bool>(json['isAntiAlias'], false) : true,
+    filterQuality: json['filterQuality'] != null ? FilterQuality.values[asT<int>(json['filterQuality'])] : FilterQuality.high,
+  );
+}
 
   void _init() {
     if (url != null && assetName != null) {


### PR DESCRIPTION
### Pull Request: Fix for Image Import Issue in Windows Application

#### Summary
This pull request addresses an issue where images imported from a JSON file were not displaying correctly in a Windows application. The widget was rendered correctly, but the images were missing. A detailed video demonstration of the issue has been attached to this pull request.

https://github.com/fluttercandies/stack_board/assets/48905483/bbf9fd6a-15aa-4394-9ae9-5faa0908059a



#### Problem Description
When compiling the code into a Windows application, images specified in a JSON file were not displayed. This was due to improper handling of null values during the deserialization process.

#### Code Changes
The primary change involves handling null values more effectively during JSON deserialization. Key changes include:
- Directly checking for null values in `url` and `assetName` fields and assigning accordingly.
- Adding null checks and default values for optional fields such as `semanticLabel`, `excludeFromSemantics`, `width`, `height`, `color`, `colorBlendMode`, `fit`, `repeat`, `matchTextDirection`, `gaplessPlayback`, `isAntiAlias`, and `filterQuality`.

These changes ensure proper handling of null values, preventing issues with rendering images when certain fields are not present in the JSON data.

#### Testing
Extensive testing was conducted to ensure the modifications fixed the issue without introducing new bugs. 

#### Conclusion
The changes made to the `ImageItemContent.fromJson` method improve the robustness of the JSON deserialization process, ensuring that images are correctly displayed in the Windows application. This pull request is critical for enhancing the user experience and functionality of the application.