### PR TITLE
Can now Lock z order of items to prevent moving to the top automatically

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.liugl.stack_board_example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,6 +36,7 @@ class ColorStackItem extends StackItem<ColorContent> {
           angle: angle,
           status: status,
           content: content,
+          lockZOrder: true,
         );
 
   @override
@@ -44,6 +45,7 @@ class ColorStackItem extends StackItem<ColorContent> {
     Offset? offset,
     double? angle,
     StackItemStatus? status,
+    bool? lockZOrder,
     ColorContent? content,
   }) {
     return ColorStackItem(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -166,7 +166,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.2.4"
   stack_trace:
     dependency: transitive
     description:

--- a/lib/src/core/stack_board_controller.dart
+++ b/lib/src/core/stack_board_controller.dart
@@ -142,6 +142,8 @@ class StackBoardController extends SafeValueNotifier<StackConfig> {
 
     final StackItem<StackItemContent> item = data[_indexMap[id]!];
 
+    if(item.lockZOrder) return;
+
     data.removeAt(_indexMap[id]!);
     data.add(item);
 
@@ -182,6 +184,15 @@ class StackBoardController extends SafeValueNotifier<StackConfig> {
   /// * 选中唯一 item
   /// * select only item
   void selectOne(String id) {
+    // 全部 item status 重置为 idle
+    setAllItemStatuses(StackItemStatus.idle);
+    // Select the item
+    setItemStatus(id, StackItemStatus.selected);
+    // Move the item to the top
+    moveItemOnTop(id);
+  }
+
+  void setItemStatus(String id, StackItemStatus status) {
     if (!_indexMap.containsKey(id)) return;
 
     final int index = _indexMap[id]!;
@@ -193,20 +204,21 @@ class StackBoardController extends SafeValueNotifier<StackConfig> {
     }
 
     final List<StackItem<StackItemContent>> data =
+    List<StackItem<StackItemContent>>.from(innerData);
+
+    innerData[index] = item.copyWith(status: status);
+
+    value = value.copyWith(data: data);
+  }
+
+  void setAllItemStatuses(StackItemStatus status) {
+    final List<StackItem<StackItemContent>> data =
         List<StackItem<StackItemContent>>.from(innerData);
 
-    data.removeAt(index);
-
-    // 全部 item status 重置为 idle
     for (int i = 0; i < data.length; i++) {
       final StackItem<StackItemContent> item = data[i];
-      data[i] = item.copyWith(status: StackItemStatus.idle);
-      _indexMap[item.id] = i;
+      data[i] = item.copyWith(status: status);
     }
-
-    data.add(item.copyWith(status: StackItemStatus.selected));
-    _indexMap[item.id] = data.length - 1;
-    // selected.add(item.id);
 
     value = value.copyWith(data: data, indexMap: _newIndexMap);
   }
@@ -339,4 +351,5 @@ class StackBoardController extends SafeValueNotifier<StackConfig> {
 
     super.dispose();
   }
+
 }

--- a/lib/src/core/stack_board_item/stack_item.dart
+++ b/lib/src/core/stack_board_item/stack_item.dart
@@ -28,10 +28,12 @@ abstract class StackItem<T extends StackItemContent> {
     Offset? offset,
     double? angle = 0,
     StackItemStatus? status = StackItemStatus.selected,
+    bool? lockZOrder = false,
     this.content,
   })  : id = id ?? _genId(),
         offset = offset ?? Offset.zero,
         angle = angle ?? 0,
+        lockZOrder = lockZOrder ?? false,
         status = status ?? StackItemStatus.selected;
 
   const StackItem.empty({
@@ -40,6 +42,7 @@ abstract class StackItem<T extends StackItemContent> {
     required this.angle,
     required this.status,
     required this.content,
+    required this.lockZOrder,
   }) : id = '';
 
   /// id
@@ -57,6 +60,8 @@ abstract class StackItem<T extends StackItemContent> {
   /// Status
   final StackItemStatus status;
 
+  final bool lockZOrder;
+
   /// Content
   final T? content;
 
@@ -66,6 +71,7 @@ abstract class StackItem<T extends StackItemContent> {
     Offset? offset,
     double? angle,
     StackItemStatus? status,
+    bool? lockZOrder,
     T? content,
   });
 
@@ -78,6 +84,7 @@ abstract class StackItem<T extends StackItemContent> {
       'size': size.toJson(),
       'offset': offset.toJson(),
       'status': status.index,
+      'lockZOrder': lockZOrder,
       if (content != null) 'content': content?.toJson(),
     };
   }

--- a/lib/src/stack_board_items/items/stack_draw_item.dart
+++ b/lib/src/stack_board_items/items/stack_draw_item.dart
@@ -67,6 +67,7 @@ class StackDrawItem extends StackItem<DrawItemContent> {
     double? angle,
     Size size = const Size(300, 300),
     Offset? offset,
+    bool? lockZOrder,
     StackItemStatus? status,
   }) : super(
             id: id,
@@ -74,6 +75,7 @@ class StackDrawItem extends StackItem<DrawItemContent> {
             offset: offset,
             angle: angle,
             status: status,
+            lockZOrder: lockZOrder,
             content: content ??
                 DrawItemContent(
                     size: size.shortestSide, paintContents: <PaintContent>[]));
@@ -102,6 +104,7 @@ class StackDrawItem extends StackItem<DrawItemContent> {
     Offset? offset,
     double? angle,
     StackItemStatus? status,
+    bool? lockZOrder,
     DrawItemContent? content,
   }) {
     return StackDrawItem(
@@ -110,6 +113,7 @@ class StackDrawItem extends StackItem<DrawItemContent> {
       offset: offset ?? this.offset,
       angle: angle ?? this.angle,
       status: status ?? this.status,
+      lockZOrder: lockZOrder ?? this.lockZOrder,
       content: content ?? this.content,
     );
   }

--- a/lib/src/stack_board_items/items/stack_draw_item.dart
+++ b/lib/src/stack_board_items/items/stack_draw_item.dart
@@ -7,6 +7,8 @@ import 'package:stack_board/src/core/stack_board_item/stack_item_status.dart';
 import 'package:stack_board/src/widget_style_extension/ex_offset.dart';
 import 'package:stack_board/src/widget_style_extension/ex_size.dart';
 
+import '../../../helpers.dart';
+
 class DrawItemContent implements StackItemContent {
   DrawItemContent({
     required this.size,
@@ -87,6 +89,7 @@ class StackDrawItem extends StackItem<DrawItemContent> {
       size: jsonToSize(data['size'] as Map<String, dynamic>),
       offset: jsonToOffset(data['offset'] as Map<String, dynamic>),
       status: StackItemStatus.values[data['status'] as int],
+      lockZOrder: asNullT<bool>(data['lockZOrder']) ?? false,
       content:
           DrawItemContent.fromJson(data['content'] as Map<String, dynamic>),
     );

--- a/lib/src/stack_board_items/items/stack_image_item.dart
+++ b/lib/src/stack_board_items/items/stack_image_item.dart
@@ -148,6 +148,7 @@ class StackImageItem extends StackItem<ImageItemContent> {
       offset:
           data['offset'] == null ? null : jsonToOffset(asMap(data['offset'])),
       status: StackItemStatus.values[data['status'] as int],
+      lockZOrder: asNullT<bool>(data['lockZOrder']) ?? false,
       content: ImageItemContent.fromJson(asMap(data['content'])),
     );
   }

--- a/lib/src/stack_board_items/items/stack_image_item.dart
+++ b/lib/src/stack_board_items/items/stack_image_item.dart
@@ -129,6 +129,7 @@ class StackImageItem extends StackItem<ImageItemContent> {
     required Size size,
     Offset? offset,
     StackItemStatus? status,
+    bool? lockZOrder,
   }) : super(
           id: id,
           size: size,
@@ -136,6 +137,7 @@ class StackImageItem extends StackItem<ImageItemContent> {
           angle: angle,
           status: status,
           content: content,
+          lockZOrder: lockZOrder,
         );
 
   factory StackImageItem.fromJson(Map<String, dynamic> data) {
@@ -164,6 +166,7 @@ class StackImageItem extends StackItem<ImageItemContent> {
     Offset? offset,
     double? angle,
     StackItemStatus? status,
+    bool? lockZOrder,
     ImageItemContent? content,
   }) {
     return StackImageItem(
@@ -172,6 +175,7 @@ class StackImageItem extends StackItem<ImageItemContent> {
       offset: offset ?? this.offset,
       angle: angle ?? this.angle,
       status: status ?? this.status,
+      lockZOrder: lockZOrder ?? this.lockZOrder,
       content: content ?? this.content,
     );
   }

--- a/lib/src/stack_board_items/items/stack_text_item.dart
+++ b/lib/src/stack_board_items/items/stack_text_item.dart
@@ -138,6 +138,7 @@ class StackTextItem extends StackItem<TextItemContent> {
       offset:
           data['offset'] == null ? null : jsonToOffset(asMap(data['offset'])),
       status: StackItemStatus.values[data['status'] as int],
+      lockZOrder: asNullT<bool>(data['lockZOrder']) ?? false,
       content: TextItemContent.fromJson(asMap(data['content'])),
     );
   }

--- a/lib/src/stack_board_items/items/stack_text_item.dart
+++ b/lib/src/stack_board_items/items/stack_text_item.dart
@@ -118,6 +118,7 @@ class StackTextItem extends StackItem<TextItemContent> {
     double? angle,
     required Size size,
     Offset? offset,
+    bool? lockZOrder,
     StackItemStatus? status,
   }) : super(
           id: id,
@@ -125,6 +126,7 @@ class StackTextItem extends StackItem<TextItemContent> {
           offset: offset,
           angle: angle,
           status: status,
+          lockZOrder: lockZOrder,
           content: content,
         );
 
@@ -152,6 +154,7 @@ class StackTextItem extends StackItem<TextItemContent> {
     Size? size,
     Offset? offset,
     StackItemStatus? status,
+    bool? lockZOrder,
     TextItemContent? content,
   }) {
     return StackTextItem(
@@ -160,6 +163,7 @@ class StackTextItem extends StackItem<TextItemContent> {
       size: size ?? this.size,
       offset: offset ?? this.offset,
       status: status ?? this.status,
+      lockZOrder: lockZOrder ?? this.lockZOrder,
       content: content ?? this.content,
     );
   }

--- a/test/stack_board_items/items/stack_draw_item.dart
+++ b/test/stack_board_items/items/stack_draw_item.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stack_board/stack_items.dart';
+
+void main() {
+  test('Stack Draw Item should save lockZorder to json', () {
+    final item = StackDrawItem(
+        content: DrawItemContent(size: 100, paintContents: []),
+        size: Size(100, 100),
+        lockZOrder: true);
+    expect(item.toJson()['lockZOrder'], true);
+  });
+
+  test('Stack Draw Item should restore lockZorder from json', () {
+    final item = StackDrawItem.fromJson({
+      'id': 'id',
+      'size': {'width': 100, 'height': 100},
+      'content': {'size': 100.0, 'paintContents': []},
+      'lockZOrder': true,
+      'offset': {'dx': 0, 'dy': 0},
+      'status': 0,
+    });
+    expect(item.lockZOrder, true);
+  });
+}

--- a/test/stack_board_items/items/stack_image_item.dart
+++ b/test/stack_board_items/items/stack_image_item.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stack_board/stack_items.dart';
+
+void main() {
+  test('Stack Image Item should save lockZorder to json', () {
+    final item = StackImageItem(
+        content: ImageItemContent(url: 'http://a.b.c'),
+        size: Size(100, 100),
+        lockZOrder: true);
+    expect(item.toJson()['lockZOrder'], true);
+  });
+
+  test('Stack Image Item should restore lockZorder from json', () {
+    final item = StackImageItem.fromJson({
+      'id': 'id',
+      'size': {'width': 100, 'height': 100},
+      'content': {'url': 'http://a.b.c'},
+      'lockZOrder': true,
+      'status': 0,
+    });
+    expect(item.lockZOrder, true);
+  });
+}

--- a/test/stack_board_items/items/stack_text_item.dart
+++ b/test/stack_board_items/items/stack_text_item.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stack_board/stack_items.dart';
+
+main() {
+  test('Stack Text Item should save lockZorder to json', () {
+    final item = StackTextItem(
+        content: TextItemContent(),
+        size: Size(100, 100),
+        lockZOrder: true);
+    expect(item.toJson()['lockZOrder'], true);
+  });
+
+  test('Stack Text Item should restore lockZorder from json', () {
+    final item = StackTextItem.fromJson({
+      'id': 'id',
+      'size': {'width': 100, 'height': 100},
+      'content': {'text': 'text'},
+      'lockZOrder': true,
+      'offset': {'dx': 0, 'dy': 0},
+      'status': 0,
+    });
+    expect(item.lockZOrder, true);
+  });
+
+}


### PR DESCRIPTION
By default the behavior is the same. Set lockZOrder to true and the item will not move to the top when tapped or dragged.