### PR TITLE
Fixed crash for missing json when text items have custom styles

### DIFF
--- a/lib/src/helpers/ex_enum.dart
+++ b/lib/src/helpers/ex_enum.dart
@@ -10,6 +10,7 @@ class ExEnum {
 
   static T? tryParse<T extends Object>(List<T> values, String? item) {
     if (item == null) return null;
+        if(item.isEmpty) return null;
     if (!_isEnum<T>(item)) throw Exception('Item $item is not ${T.toString()}');
 
     for (final T value in values) {


### PR DESCRIPTION
If you set a text style on a TextItemContent convert is to json then back to TextItemContent. The library will crash. Since TextDecoration may be missing. This fixes that.